### PR TITLE
Fixed value checks not working for enums defined in <$varlist>

### DIFF
--- a/src/hsclib/defattr.c
+++ b/src/hsclib/defattr.c
@@ -513,7 +513,8 @@ static HSCATTR *copy_local_var(DLLIST * destlist, HSCATTR * locvar, ULONG mci)
    var->varflag = locvar->varflag & (~VF_MACRO);       /* disable VF_MACRO */
    set_vartext(var, locvar->text);
    var->quote = locvar->quote;
-   
+   var->enumstr = locvar->enumstr ? strclone(locvar->enumstr) : NULL;
+
    return (var);
 }
 


### PR DESCRIPTION
Enumarations inherited from a `<$varlist>` definition did not get their values checked thus giving no warning about unknown enumerator values.

For example, this test input uses the `<img>` tag which inherits ALIGN from `<$varlist __IAlign>` and `<bdo>` which defines an enumeration for DIR on its own.

```
<html>
  <head>
  </head>
  <body>
    <bdo lang="de" dir="rtls">
    <img src="foo.png" alt="foo" align="tops">
  </body>
</html>
```

Running hsc with this test input yields a warning for `<bdo>` only but not for `<img>` as expected:

```
/usr/local/bin/hsc prefsfile=hsc.prefs co qs=double es=utf-8 test.hsc
hsc.prefs (reading)
test.hsc (reading) 
test.hsc (reading)
test.hsc (5,30): Warning 35: unknown value `rtls' for enumerator attribute DIR
test.hsc (9)      
test.hsc (9)
```
