### PR TITLE
fprintf -> fputs

### DIFF
--- a/src/hsc/hsc.c
+++ b/src/hsc/hsc.c
@@ -213,7 +213,7 @@ static BOOL hsc_init_project(HSCPRC * hp, STRPTR project_fname)
     return (ok);
 }
 
-void fpf(FILE *s, APTR d) { fprintf(s,d); }
+void fpf(FILE *s, APTR d) { fputs(d,s); }
 /*
  * hsc_main()
  */

--- a/src/hscprj/license.c
+++ b/src/hscprj/license.c
@@ -59,8 +59,8 @@ hsc_license2 =
  */
 void show_license(void)
 {
-   /* 2*printf just to avoid compiler moaning */
-   fprintf(stderr, hsc_license1);
-   fprintf(stderr, hsc_license2);
+   /* 2*fputs just to avoid compiler moaning */
+   fputs(hsc_license1, stderr);
+   fputs(hsc_license2, stderr);
 }
 


### PR DESCRIPTION
plain strings were used as format strings
forbidden by gcc's -Wformat-security